### PR TITLE
Allow customizing the cache filename with env var CACHE_REQUIRE_PATHS_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ require('cache-require-paths');
 ...
 ```
 
-The first time the app loads a cache of resolved file paths will be saved in a local `.` file.
-Every application startup after that will reuse this filename cache to avoid "hunting" for right
-filename.
+The first time the app loads, a cache of resolved file paths will be saved to `.cache-require-paths.json`
+in the current directory.  Every application startup after that will reuse this filename cache to avoid
+"hunting" for the right filename.
+
+To save cached paths to a different file, set the environmental variable `CACHE_REQUIRE_PATHS_FILE`.
 
 ## Results
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
-var SAVE_FILENAME = './.cache-require-paths.json';
 var Module = require('module');
 var fs = require('fs');
 var exists = fs.existsSync;
 
 var _require = Module.prototype.require;
+var SAVE_FILENAME =
+  process.env.CACHE_REQUIRE_PATHS_FILE ?
+  process.env.CACHE_REQUIRE_PATHS_FILE :
+  './.cache-require-paths.json';
 var nameCache = exists(SAVE_FILENAME) ? JSON.parse(fs.readFileSync(SAVE_FILENAME, 'utf-8')) : {};
 
 var currentModuleCache;


### PR DESCRIPTION
Thanks for the very handy library!

I'm working on a command line tool that needs to work in any directory, so I've added a feature to cache-require-paths that lets you set the environmental variable `CACHE_REQUIRE_PATHS_FILE` to write cached paths to a different file.  This way, I don't drop a `.cache-require-paths.json` in a ton of different directories.
