### PR TITLE
Don't raise an exception if saving failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ function printCache() {
 }
 
 process.once('exit', function () {
-  fs.writeFileSync(SAVE_FILENAME,
-    JSON.stringify(nameCache, null, 2), 'utf-8');
+  try {
+    fs.writeFileSync(SAVE_FILENAME,
+      JSON.stringify(nameCache, null, 2), 'utf-8');
+  } catch (err) {
+    console.error('cache-require-paths: Failed saving cache: ' + err.toString());
+  }
 });


### PR DESCRIPTION
I don't believe not writing the cache should fail silently; but it also shouldn't raise an exception which was causing test failures for us.
