### PR TITLE
Fix endless recursion

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,21 +28,16 @@ Module.prototype.require = function cachePathsRequire(name) {
     // Some people hack Object.prototype to insert their own properties on
     // every dictionary (for example, the 'should' testing framework). Check
     // that the key represents a path.
-    typeof currentModuleCache[name] === 'string') {
+    typeof currentModuleCache[name] === 'string' &&
+    fs.existsSync(currentModuleCache[name]) // the file must exist for a cache hit
+  ) {
     pathToLoad = currentModuleCache[name];
   } else {
     pathToLoad = Module._resolveFilename(name, this);
     currentModuleCache[name] = pathToLoad;
   }
 
-  try {
-    return _require.call(this, pathToLoad);
-  } catch (err) {
-    // Cache may be outdated; resolve and try again
-    pathToLoad = Module._resolveFilename(name, this);
-    currentModuleCache[name] = pathToLoad;
-    return _require.call(this, pathToLoad);
-  }
+  return _require.call(this, pathToLoad);
 };
 
 function printCache() {


### PR DESCRIPTION
We were using this package to improve the performance of our tests, but we hit a special case where a misspelled require caused an endless (or at least, very very long) loop. `mocha` timed out after 10 minutes.

The current logic of `cache-require-paths` to identify a cache mismatch is to try to require, catch any exception and try again. The existence of the required package was never checked.

This pull-request adds a check to only a cache match when the file exists. This makes the `try`-`catch` redundant, so it was removed.

We tried to create a test fixture that proves our problem, but failed to do so. Nevertheless, we wish to share our fix.